### PR TITLE
fix share encryption

### DIFF
--- a/crypto/rsa.go
+++ b/crypto/rsa.go
@@ -77,3 +77,7 @@ func EncodeRSAPublicKey(pk *rsa.PublicKey) ([]byte, error) {
 func Encrypt(pub *rsa.PublicKey, msg []byte) ([]byte, error) {
 	return rsa.EncryptPKCS1v15(rand.Reader, pub, msg)
 }
+
+func Decrypt(pk *rsa.PrivateKey, msg []byte) ([]byte, error) {
+	return rsa.DecryptPKCS1v15(rand.Reader, pk, msg)
+}

--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -39,7 +39,7 @@ func VerifySignedMessageByOwner(
 		address := eth_crypto.PubkeyToAddress(*pk)
 
 		if common.Address(owner).Cmp(address) != 0 {
-			return fmt.Errorf("invalid signed reshare signature")
+			return fmt.Errorf("signature invalid")
 		}
 	} else {
 		// EIP 1271 signature

--- a/crypto/signature_test.go
+++ b/crypto/signature_test.go
@@ -78,7 +78,7 @@ func TestVerifySignedReshare(t *testing.T) {
 		require.EqualError(t, VerifySignedMessageByOwner(stubClient,
 			[20]byte{},
 			plain,
-			sig), "invalid signed reshare signature")
+			sig), "signature invalid")
 	})
 
 	t.Run("valid contract signature", func(t *testing.T) {

--- a/operator.go
+++ b/operator.go
@@ -38,7 +38,7 @@ func (op *Operator) Init(
 	depositDataSig := share.SignByte(depositDataRoot[:])
 
 	// sign proof
-	encryptedShare, err := crypto.Encrypt(&sk.PublicKey, share.Serialize())
+	encryptedShare, err := crypto.Encrypt(&sk.PublicKey, []byte(share.SerializeToHexStr()))
 	if err != nil {
 		return nil, err
 	}

--- a/result.go
+++ b/result.go
@@ -5,12 +5,11 @@ import (
 	"crypto/rsa"
 	"fmt"
 
-	"github.com/ssvlabs/dkg-spec/crypto"
-
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
 	eth_crypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/herumi/bls-eth-go-binary/bls"
+	"github.com/ssvlabs/dkg-spec/crypto"
 )
 
 func BuildResult(
@@ -37,7 +36,7 @@ func BuildResult(
 	depositDataSig := share.SignByte(depositDataRoot[:])
 
 	// sign proof
-	encryptedShare, err := crypto.Encrypt(&sk.PublicKey, share.Serialize())
+	encryptedShare, err := crypto.Encrypt(&sk.PublicKey, []byte(share.SerializeToHexStr()))
 	if err != nil {
 		return nil, err
 	}

--- a/testing/result_test.go
+++ b/testing/result_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	spec "github.com/ssvlabs/dkg-spec"
+	spec_crypto "github.com/ssvlabs/dkg-spec/crypto"
 	"github.com/ssvlabs/dkg-spec/testing/fixtures"
 
 	"github.com/stretchr/testify/require"
@@ -34,8 +35,10 @@ func TestBuildResult(t *testing.T) {
 			fixtures.TestNonce,
 			result,
 		))
+		decryptedShare, err := spec_crypto.Decrypt(fixtures.OperatorSK(fixtures.TestOperator1SK), result.SignedProof.Proof.EncryptedShare)
+		require.NoError(t, err)
+		require.EqualValues(t, []byte(fixtures.ShareSK(fixtures.TestValidator4OperatorsShare1).SerializeToHexStr()), decryptedShare)
 	})
-
 }
 
 func TestValidateResults(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -43,7 +43,7 @@ type Reshare struct {
 
 type SignedReshare struct {
 	Reshare Reshare
-	// Signature is an ECDSA signature over proof
+	// Signature is an ECDSA signature over reshare hash
 	Signature []byte `ssz-max:"1536"` // 64 * 24
 }
 


### PR DESCRIPTION
* fix BLS share encryption. SSV node expects encoded hex string not bytes (https://github.com/ssvlabs/ssv/blob/main/eth/eventhandler/handlers.go#L295)
* comment is confusing `// Signature is an ECDSA signature over proof`. When we validate we check a signature on the reshare message not proofs.