### PR TITLE
feat: add support of sepolia and hoodi

### DIFF
--- a/crypto/beacon.go
+++ b/crypto/beacon.go
@@ -20,8 +20,11 @@ const (
 //
 //	TODO: once eth2_key_manager implements this we can get rid of it and support all networks ekm supports automatically
 func GetNetworkByFork(fork [4]byte) (core.Network, error) {
-
 	switch fork {
+	case [4]byte{0x90, 0x00, 0x00, 0x69}:
+		return core.SepoliaNetwork, nil
+	case [4]byte{0x10, 0x00, 0x09, 0x10}:
+		return core.HoodiNetwork, nil
 	case [4]byte{0x00, 0x00, 0x10, 0x20}:
 		return core.PraterNetwork, nil
 	case [4]byte{0x01, 0x01, 0x70, 0x00}:

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/ssvlabs/dkg-spec
 go 1.24
 
 require (
-	github.com/attestantio/go-eth2-client v0.24.0
+	github.com/attestantio/go-eth2-client v0.24.1
 	github.com/ethereum/go-ethereum v1.15.4
 	github.com/ferranbt/fastssz v0.1.4
 	github.com/google/uuid v1.6.0
 	github.com/herumi/bls-eth-go-binary v1.36.4
-	github.com/ssvlabs/eth2-key-manager v1.5.1
+	github.com/ssvlabs/eth2-key-manager v1.5.3
 	github.com/stretchr/testify v1.10.0
 	github.com/wealdtech/go-eth2-types/v2 v2.8.2
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=
 github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkThDcMsQicp4xDukwJYI=
-github.com/attestantio/go-eth2-client v0.24.0 h1:lGVbcnhlBwRglt1Zs56JOCgXVyLWKFZOmZN8jKhE7Ws=
-github.com/attestantio/go-eth2-client v0.24.0/go.mod h1:/KTLN3WuH1xrJL7ZZrpBoWM1xCCihnFbzequD5L+83o=
+github.com/attestantio/go-eth2-client v0.24.1 h1:DZ/2O83eUcSfPPs63xF6fdXDe4afA4nlt5j0y2cweOI=
+github.com/attestantio/go-eth2-client v0.24.1/go.mod h1:/KTLN3WuH1xrJL7ZZrpBoWM1xCCihnFbzequD5L+83o=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bits-and-blooms/bitset v1.21.0 h1:9RlxRbMI5dRNNburKqfDSiz5POfImKgtablyV01WUw0=
@@ -168,8 +168,8 @@ github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKl
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/ssvlabs/eth2-key-manager v1.5.1 h1:fijves+7CarWW8GlCuCXhLZFxOH4qv8J+NSchPBdntA=
-github.com/ssvlabs/eth2-key-manager v1.5.1/go.mod h1:yeUzAP+SBJXgeXPiGBrLeLuHIQCpeJZV7Jz3Fwzm/zk=
+github.com/ssvlabs/eth2-key-manager v1.5.3 h1:B9U+mrdQpWMWfIEhWGW2m3b95IqvzFv9sLtq7kQEcyI=
+github.com/ssvlabs/eth2-key-manager v1.5.3/go.mod h1:yeUzAP+SBJXgeXPiGBrLeLuHIQCpeJZV7Jz3Fwzm/zk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=


### PR DESCRIPTION
This PR adds support of new testnet `Hoodi` and older one sepolia, most of the logic is in ekm so no many changes needed