### PR TITLE
fix(EIP-1271) - change function parameter type and selector

### DIFF
--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -60,11 +60,11 @@ func VerifySignedMessageByOwner(
 		}
 		res, err := signerVerification.IsValidSignature(&bind.CallOpts{
 			Context: context.Background(),
-		}, hash[:], signature)
+		}, hash, signature)
 		if err != nil {
 			return err
 		}
-		if bytes.Equal(eip1271.MAGIC_VALUE_PERSONAL_SIGN[:], res[:]) || bytes.Equal(eip1271.MAGIC_VALUE_ETH_SIGN[:], res[:]) {
+		if bytes.Equal(eip1271.MAGIC_VALUE[:], res[:]) {
 			return nil
 		}
 		return fmt.Errorf("invalid eip1271 signature")

--- a/crypto/signature_test.go
+++ b/crypto/signature_test.go
@@ -121,6 +121,8 @@ func TestVerifySignedReshare(t *testing.T) {
 
 		stubClient := &stubs.Client{
 			CallContractF: func(call ethereum.CallMsg) ([]byte, error) {
+				require.Equal(t, []byte{0x16, 0x26, 0xba, 0x7e}, call.Data[:4], "wrong EIP-1271 selector")
+
 				ret := make([]byte, 32) // needs to be 32 byte for packing
 				copy(ret[:4], eip1271.MAGIC_VALUE[:])
 
@@ -151,6 +153,8 @@ func TestVerifySignedReshare(t *testing.T) {
 
 		stubClient := &stubs.Client{
 			CallContractF: func(call ethereum.CallMsg) ([]byte, error) {
+				require.Equal(t, []byte{0x16, 0x26, 0xba, 0x7e}, call.Data[:4], "wrong EIP-1271 selector")
+
 				ret := make([]byte, 32) // needs to be 32 byte for packing
 				copy(ret[:4], eip1271.InvalidSigValue[:])
 

--- a/crypto/signature_test.go
+++ b/crypto/signature_test.go
@@ -122,7 +122,7 @@ func TestVerifySignedReshare(t *testing.T) {
 		stubClient := &stubs.Client{
 			CallContractF: func(call ethereum.CallMsg) ([]byte, error) {
 				ret := make([]byte, 32) // needs to be 32 byte for packing
-				copy(ret[:4], eip1271.MAGIC_VALUE_ETH_SIGN[:])
+				copy(ret[:4], eip1271.MAGIC_VALUE[:])
 
 				return ret, nil
 			},

--- a/eip1271/abi.abi
+++ b/eip1271/abi.abi
@@ -3,8 +3,8 @@
     "constant": true,
     "inputs": [
       {
-        "name": "_data",
-        "type": "bytes"
+        "name": "_hash",
+        "type": "bytes32"
       },
       {
         "name": "_signature",

--- a/eip1271/common.go
+++ b/eip1271/common.go
@@ -10,11 +10,11 @@ import (
 // EIP-1271 magic values (https://eips.ethereum.org/EIPS/eip-1271)
 // The four-byte code is defined as follows:
 // - 0x00000000 if the signature is invalid.
-// - 0x20c13b0b if the signature is valid and was produced using the eth_sign method.
-// - 0x1626ba7e if the signature is valid and was produced using the personal_sign method.
+// - 0x1626ba7e if the signature is valid (standard EIP-1271, selector of isValidSignature(bytes32,bytes)).
 
-var MAGIC_VALUE_ETH_SIGN = [4]byte{0x16, 0x26, 0xba, 0x7e}
-var MAGIC_VALUE_PERSONAL_SIGN = [4]byte{0x20, 0xc1, 0x3b, 0x0b}
+// MAGIC_VALUE is the standard EIP-1271 magic value (0x1626ba7e).
+var MAGIC_VALUE = [4]byte{0x16, 0x26, 0xba, 0x7e}
+
 var InvalidSigValue = [4]byte{0xff, 0xff, 0xff, 0xff}
 
 type ETHClient interface {

--- a/eip1271/eip1271.go
+++ b/eip1271/eip1271.go
@@ -31,7 +31,7 @@ var (
 
 // Eip1271MetaData contains all meta data concerning the Eip1271 contract.
 var Eip1271MetaData = &bind.MetaData{
-	ABI: "[{\"constant\":true,\"inputs\":[{\"name\":\"_data\",\"type\":\"bytes\"},{\"name\":\"_signature\",\"type\":\"bytes\"}],\"name\":\"isValidSignature\",\"outputs\":[{\"name\":\"magicValue\",\"type\":\"bytes4\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"}]",
+	ABI: "[{\"constant\":true,\"inputs\":[{\"name\":\"_hash\",\"type\":\"bytes32\"},{\"name\":\"_signature\",\"type\":\"bytes\"}],\"name\":\"isValidSignature\",\"outputs\":[{\"name\":\"magicValue\",\"type\":\"bytes4\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"}]",
 }
 
 // Eip1271ABI is the input ABI used to generate the binding from.
@@ -180,12 +180,12 @@ func (_Eip1271 *Eip1271TransactorRaw) Transact(opts *bind.TransactOpts, method s
 	return _Eip1271.Contract.contract.Transact(opts, method, params...)
 }
 
-// IsValidSignature is a free data retrieval call binding the contract method 0x20c13b0b.
+// IsValidSignature is a free data retrieval call binding the contract method 0x1626ba7e.
 //
-// Solidity: function isValidSignature(bytes _data, bytes _signature) view returns(bytes4 magicValue)
-func (_Eip1271 *Eip1271Caller) IsValidSignature(opts *bind.CallOpts, _data []byte, _signature []byte) ([4]byte, error) {
+// Solidity: function isValidSignature(bytes32 _hash, bytes _signature) view returns(bytes4 magicValue)
+func (_Eip1271 *Eip1271Caller) IsValidSignature(opts *bind.CallOpts, _hash [32]byte, _signature []byte) ([4]byte, error) {
 	var out []interface{}
-	err := _Eip1271.contract.Call(opts, &out, "isValidSignature", _data, _signature)
+	err := _Eip1271.contract.Call(opts, &out, "isValidSignature", _hash, _signature)
 
 	if err != nil {
 		return *new([4]byte), err
@@ -197,16 +197,16 @@ func (_Eip1271 *Eip1271Caller) IsValidSignature(opts *bind.CallOpts, _data []byt
 
 }
 
-// IsValidSignature is a free data retrieval call binding the contract method 0x20c13b0b.
+// IsValidSignature is a free data retrieval call binding the contract method 0x1626ba7e.
 //
-// Solidity: function isValidSignature(bytes _data, bytes _signature) view returns(bytes4 magicValue)
-func (_Eip1271 *Eip1271Session) IsValidSignature(_data []byte, _signature []byte) ([4]byte, error) {
-	return _Eip1271.Contract.IsValidSignature(&_Eip1271.CallOpts, _data, _signature)
+// Solidity: function isValidSignature(bytes32 _hash, bytes _signature) view returns(bytes4 magicValue)
+func (_Eip1271 *Eip1271Session) IsValidSignature(_hash [32]byte, _signature []byte) ([4]byte, error) {
+	return _Eip1271.Contract.IsValidSignature(&_Eip1271.CallOpts, _hash, _signature)
 }
 
-// IsValidSignature is a free data retrieval call binding the contract method 0x20c13b0b.
+// IsValidSignature is a free data retrieval call binding the contract method 0x1626ba7e.
 //
-// Solidity: function isValidSignature(bytes _data, bytes _signature) view returns(bytes4 magicValue)
-func (_Eip1271 *Eip1271CallerSession) IsValidSignature(_data []byte, _signature []byte) ([4]byte, error) {
-	return _Eip1271.Contract.IsValidSignature(&_Eip1271.CallOpts, _data, _signature)
+// Solidity: function isValidSignature(bytes32 _hash, bytes _signature) view returns(bytes4 magicValue)
+func (_Eip1271 *Eip1271CallerSession) IsValidSignature(_hash [32]byte, _signature []byte) ([4]byte, error) {
+	return _Eip1271.Contract.IsValidSignature(&_Eip1271.CallOpts, _hash, _signature)
 }

--- a/types_encoding.go
+++ b/types_encoding.go
@@ -22,7 +22,6 @@ func (o *Operator) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (1) 'PubKey'
 	dst = ssz.WriteOffset(dst, offset)
-	offset += len(o.PubKey)
 
 	// Field (1) 'PubKey'
 	if size := len(o.PubKey); size > 2048 {
@@ -53,7 +52,7 @@ func (o *Operator) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o1 < 12 {
+	if o1 != 12 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -136,7 +135,6 @@ func (i *Init) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (2) 'WithdrawalCredentials'
 	dst = ssz.WriteOffset(dst, offset)
-	offset += len(i.WithdrawalCredentials)
 
 	// Field (3) 'Fork'
 	dst = append(dst, i.Fork[:]...)
@@ -194,7 +192,7 @@ func (i *Init) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 < 56 {
+	if o0 != 56 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -373,7 +371,6 @@ func (r *Reshare) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (6) 'WithdrawalCredentials'
 	dst = ssz.WriteOffset(dst, offset)
-	offset += len(r.WithdrawalCredentials)
 
 	// Field (7) 'Owner'
 	dst = append(dst, r.Owner[:]...)
@@ -452,7 +449,7 @@ func (r *Reshare) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o1 < 116 {
+	if o1 != 116 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -670,10 +667,6 @@ func (r *ReshareMessage) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (1) 'Proofs'
 	dst = ssz.WriteOffset(dst, offset)
-	for ii := 0; ii < len(r.Proofs); ii++ {
-		offset += 4
-		offset += r.Proofs[ii].SizeSSZ()
-	}
 
 	// Field (0) 'Reshare'
 	if dst, err = r.Reshare.MarshalSSZTo(dst); err != nil {
@@ -717,7 +710,7 @@ func (r *ReshareMessage) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 < 8 {
+	if o0 != 8 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -838,7 +831,6 @@ func (s *SignedReshare) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (1) 'Signature'
 	dst = ssz.WriteOffset(dst, offset)
-	offset += len(s.Signature)
 
 	// Field (0) 'Messages'
 	if size := len(s.Messages); size > 100 {
@@ -884,7 +876,7 @@ func (s *SignedReshare) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 < 8 {
+	if o0 != 8 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -1013,7 +1005,6 @@ func (r *Resign) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (2) 'WithdrawalCredentials'
 	dst = ssz.WriteOffset(dst, offset)
-	offset += len(r.WithdrawalCredentials)
 
 	// Field (3) 'Owner'
 	dst = append(dst, r.Owner[:]...)
@@ -1059,7 +1050,7 @@ func (r *Resign) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o2 < 92 {
+	if o2 != 92 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -1171,10 +1162,6 @@ func (r *ResignMessage) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (2) 'Proofs'
 	dst = ssz.WriteOffset(dst, offset)
-	for ii := 0; ii < len(r.Proofs); ii++ {
-		offset += 4
-		offset += r.Proofs[ii].SizeSSZ()
-	}
 
 	// Field (0) 'Operators'
 	if size := len(r.Operators); size > 13 {
@@ -1236,7 +1223,7 @@ func (r *ResignMessage) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 < 12 {
+	if o0 != 12 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -1406,7 +1393,6 @@ func (s *SignedResign) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (1) 'Signature'
 	dst = ssz.WriteOffset(dst, offset)
-	offset += len(s.Signature)
 
 	// Field (0) 'Messages'
 	if size := len(s.Messages); size > 100 {
@@ -1452,7 +1438,7 @@ func (s *SignedResign) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 < 8 {
+	if o0 != 8 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -1591,7 +1577,6 @@ func (r *Result) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (4) 'SignedProof'
 	dst = ssz.WriteOffset(dst, offset)
-	offset += r.SignedProof.SizeSSZ()
 
 	// Field (4) 'SignedProof'
 	if dst, err = r.SignedProof.MarshalSSZTo(dst); err != nil {
@@ -1635,7 +1620,7 @@ func (r *Result) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o4 < 228 {
+	if o4 != 228 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -1721,7 +1706,6 @@ func (p *Proof) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (1) 'EncryptedShare'
 	dst = ssz.WriteOffset(dst, offset)
-	offset += len(p.EncryptedShare)
 
 	// Field (2) 'SharePubKey'
 	if size := len(p.SharePubKey); size != 48 {
@@ -1765,7 +1749,7 @@ func (p *Proof) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o1 < 120 {
+	if o1 != 120 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -1861,10 +1845,6 @@ func (s *SignedProof) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (0) 'Proof'
 	dst = ssz.WriteOffset(dst, offset)
-	if s.Proof == nil {
-		s.Proof = new(Proof)
-	}
-	offset += s.Proof.SizeSSZ()
 
 	// Field (1) 'Signature'
 	if size := len(s.Signature); size != 256 {
@@ -1897,7 +1877,7 @@ func (s *SignedProof) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 < 260 {
+	if o0 != 260 {
 		return ssz.ErrInvalidVariableOffset
 	}
 

--- a/types_encoding.go
+++ b/types_encoding.go
@@ -22,6 +22,7 @@ func (o *Operator) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (1) 'PubKey'
 	dst = ssz.WriteOffset(dst, offset)
+	offset += len(o.PubKey)
 
 	// Field (1) 'PubKey'
 	if size := len(o.PubKey); size > 2048 {
@@ -52,7 +53,7 @@ func (o *Operator) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o1 != 12 {
+	if o1 < 12 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -135,6 +136,7 @@ func (i *Init) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (2) 'WithdrawalCredentials'
 	dst = ssz.WriteOffset(dst, offset)
+	offset += len(i.WithdrawalCredentials)
 
 	// Field (3) 'Fork'
 	dst = append(dst, i.Fork[:]...)
@@ -192,7 +194,7 @@ func (i *Init) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 != 56 {
+	if o0 < 56 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -371,6 +373,7 @@ func (r *Reshare) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (6) 'WithdrawalCredentials'
 	dst = ssz.WriteOffset(dst, offset)
+	offset += len(r.WithdrawalCredentials)
 
 	// Field (7) 'Owner'
 	dst = append(dst, r.Owner[:]...)
@@ -449,7 +452,7 @@ func (r *Reshare) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o1 != 116 {
+	if o1 < 116 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -667,6 +670,10 @@ func (r *ReshareMessage) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (1) 'Proofs'
 	dst = ssz.WriteOffset(dst, offset)
+	for ii := 0; ii < len(r.Proofs); ii++ {
+		offset += 4
+		offset += r.Proofs[ii].SizeSSZ()
+	}
 
 	// Field (0) 'Reshare'
 	if dst, err = r.Reshare.MarshalSSZTo(dst); err != nil {
@@ -710,7 +717,7 @@ func (r *ReshareMessage) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 != 8 {
+	if o0 < 8 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -831,6 +838,7 @@ func (s *SignedReshare) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (1) 'Signature'
 	dst = ssz.WriteOffset(dst, offset)
+	offset += len(s.Signature)
 
 	// Field (0) 'Messages'
 	if size := len(s.Messages); size > 100 {
@@ -876,7 +884,7 @@ func (s *SignedReshare) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 != 8 {
+	if o0 < 8 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -1005,6 +1013,7 @@ func (r *Resign) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (2) 'WithdrawalCredentials'
 	dst = ssz.WriteOffset(dst, offset)
+	offset += len(r.WithdrawalCredentials)
 
 	// Field (3) 'Owner'
 	dst = append(dst, r.Owner[:]...)
@@ -1050,7 +1059,7 @@ func (r *Resign) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o2 != 92 {
+	if o2 < 92 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -1162,6 +1171,10 @@ func (r *ResignMessage) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (2) 'Proofs'
 	dst = ssz.WriteOffset(dst, offset)
+	for ii := 0; ii < len(r.Proofs); ii++ {
+		offset += 4
+		offset += r.Proofs[ii].SizeSSZ()
+	}
 
 	// Field (0) 'Operators'
 	if size := len(r.Operators); size > 13 {
@@ -1223,7 +1236,7 @@ func (r *ResignMessage) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 != 12 {
+	if o0 < 12 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -1393,6 +1406,7 @@ func (s *SignedResign) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (1) 'Signature'
 	dst = ssz.WriteOffset(dst, offset)
+	offset += len(s.Signature)
 
 	// Field (0) 'Messages'
 	if size := len(s.Messages); size > 100 {
@@ -1438,7 +1452,7 @@ func (s *SignedResign) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 != 8 {
+	if o0 < 8 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -1577,6 +1591,7 @@ func (r *Result) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (4) 'SignedProof'
 	dst = ssz.WriteOffset(dst, offset)
+	offset += r.SignedProof.SizeSSZ()
 
 	// Field (4) 'SignedProof'
 	if dst, err = r.SignedProof.MarshalSSZTo(dst); err != nil {
@@ -1620,7 +1635,7 @@ func (r *Result) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o4 != 228 {
+	if o4 < 228 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -1706,6 +1721,7 @@ func (p *Proof) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (1) 'EncryptedShare'
 	dst = ssz.WriteOffset(dst, offset)
+	offset += len(p.EncryptedShare)
 
 	// Field (2) 'SharePubKey'
 	if size := len(p.SharePubKey); size != 48 {
@@ -1749,7 +1765,7 @@ func (p *Proof) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o1 != 120 {
+	if o1 < 120 {
 		return ssz.ErrInvalidVariableOffset
 	}
 
@@ -1845,6 +1861,10 @@ func (s *SignedProof) MarshalSSZTo(buf []byte) (dst []byte, err error) {
 
 	// Offset (0) 'Proof'
 	dst = ssz.WriteOffset(dst, offset)
+	if s.Proof == nil {
+		s.Proof = new(Proof)
+	}
+	offset += s.Proof.SizeSSZ()
 
 	// Field (1) 'Signature'
 	if size := len(s.Signature); size != 256 {
@@ -1877,7 +1897,7 @@ func (s *SignedProof) UnmarshalSSZ(buf []byte) error {
 		return ssz.ErrOffset
 	}
 
-	if o0 != 260 {
+	if o0 < 260 {
 		return ssz.ErrInvalidVariableOffset
 	}
 


### PR DESCRIPTION
## Summary

- Fixed EIP-1271 ABI to use standard `isValidSignature(bytes32,bytes)` interface instead of legacy `isValidSignature(bytes,bytes)`
- Regenerated contract bindings (selector changed from `0x20c13b0b` to `0x1626ba7e`)
- Updated signature verification to pass `[32]byte` directly and check only the standard magic value
- Added selector assertion in test stubs to catch ABI regressions locally

## Context

Smart contract wallets (Gnosis Safe, etc.) implementing standard EIP-1271 did not match the legacy selector, causing reshare and resign operations with multisig owners to fail.

## Why there were two magic values

In EIP-1271, when a contract's `isValidSignature` confirms a valid signature, it returns its own 4-byte function selector as the success indicator. Since a Solidity function selector is `keccak256("functionName(argTypes)")[:4]`, two different interface versions produce two different magic values:

- `keccak256("isValidSignature(bytes32,bytes)")[:4]` = `0x1626ba7e` (finalized EIP-1271)
- `keccak256("isValidSignature(bytes,bytes)")[:4]` = `0x20c13b0b` (legacy draft)

The old code stored both selectors as magic values (mislabeled — the finalized `0x1626ba7e` was called `MAGIC_VALUE_ETH_SIGN` and the legacy draft `0x20c13b0b` was called `MAGIC_VALUE_PERSONAL_SIGN`) to handle contracts implementing either version. But since the ABI was actually using the legacy `(bytes,bytes)` interface, only `0x20c13b0b` could ever be returned — making the other magic value dead code. Now that the ABI is fixed to the standard `(bytes32,bytes)`, only `0x1626ba7e` can be returned, so we only need one.

Closes #25 
Closes #26 