### PR TITLE
chore(ci) - Update actions base image to node:24

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Go
         uses: actions/setup-go@v6.3.0
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6.3.0
         with:
           go-version: '1.21'
       - name: Install dependencies

--- a/.github/workflows/ssz_generate.yml
+++ b/.github/workflows/ssz_generate.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Go
         uses: actions/setup-go@v6.3.0
         with:

--- a/.github/workflows/ssz_generate.yml
+++ b/.github/workflows/ssz_generate.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6.3.0
         with:
           go-version: '1.21'
       - name: Install abigen
-        uses: gacts/install-geth-tools@v1
+        uses: gacts/install-geth-tools@v1.2.6
         with:
           tools: abigen
       - name: Generate


### PR DESCRIPTION
## Summary
GitHub is enforcing Node.js 24 for GitHub Actions runtime and will block workflows that rely on older Node runtimes.

This PR updates CI workflows to align with the requirement.

## Changes
- Update reusable action references (`uses:`) to latest released versions.
- Update workflow Node container images (`node:<version>`) to `node:24` where they were below 24.